### PR TITLE
Make pie chart width dynamic

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -29,7 +29,7 @@
         <b>Total yield: {{ stacked_assets["Total yield value"] }} USD</b>
     </div>
     {% if title == "Portfolio tracker" %}
-    <img src="{{ url_for('static', filename='pie_chart.png') }}" class="img-fluid" alt="Assets distribution in the portfolio by value">
+    <img src="{{ url_for('static', filename='pie_chart.png') }}" style="max-width: 100%;" alt="Assets distribution in the portfolio by value">
     {% endif %}
 </div>
 <div style="float:right; width:50%;">


### PR DESCRIPTION
This will cause the pie chart to shrink to the width of its parent <div> to eliminate the overlap on smaller screens especially mobile. The original way of using the bootstrap class="img-fluid" wasn't working for some reason. This is a simple fix though.