### PR TITLE
added punk popovers, small formatting

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -38,12 +38,14 @@ ethereum.request({method: 'eth_requestAccounts'}).then(async function (accounts)
   provider = new ethers.providers.Web3Provider(ethereum);
 
   const network = await provider.getNetwork();
-  if (network["chainId"] !== 10000) {
-    document.getElementById("msg").display = "inline-block";
-    document.getElementById("msg").textContent = "Switch to SmartBCH!";
-    return;
-  } else {
-    document.getElementById("msg").display = "none";
+  if (document.getElementById("msg")){
+    if (network["chainId"] !== 10000) {
+      document.getElementById("msg").display = "inline-block";
+      document.getElementById("msg").textContent = "Switch to SmartBCH!";
+      return;
+    } else {
+      document.getElementById("msg").display = "none";
+    }
   }
 
   // okay, confirmed we're on mainnet
@@ -53,7 +55,19 @@ ethereum.request({method: 'eth_requestAccounts'}).then(async function (accounts)
   // allow user to log in
   const submitProposalButton =
    document.getElementById("login");
-  submitProposalButton.disabled = false;
-  signer = provider.getSigner();
+  if(submitProposalButton){
+    submitProposalButton.disabled = false;
+    signer = provider.getSigner();
+  }
 
 });
+
+function onPunkHover(event, id){
+  $("#"+id).show();
+  return false;
+}
+
+function onPunkLeaveHover(id){
+  $("#"+id).hide();
+  return false;
+}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -227,3 +227,49 @@ a:hover{
         color: #f8fdff;
         text-decoration: none;
     }
+
+/* Directly from BlockNG's Website */
+.global-pixelated {
+  -ms-interpolation-mode: nearest-neighbor;
+  image-rendering: -moz-crisp-edges;
+  image-rendering: pixelated
+}
+.global-tv {
+  -webkit-mask-image: repeating-linear-gradient(#000,#000 .3rem,rgba(0,0,0,.5) .6rem);
+  mask-image: repeating-linear-gradient(#000,#000 .3rem,rgba(0,0,0,.5) .6rem);
+  -webkit-mask-position: center 0;
+  mask-position: center 0;
+  -webkit-animation: future-tv-lines linear infinite;
+  animation: future-tv-lines linear infinite;
+  -webkit-animation-duration: .5s;
+  animation-duration: .5s;
+  --playstate: var(--media-prefers-reduced-motion) paused;
+  -webkit-animation-play-state: running;
+  animation-play-state: running;
+  -webkit-animation-play-state: var(--playstate,running);
+  animation-play-state: var(--playstate,running)
+}
+
+@-webkit-keyframes future-tv-lines {
+  0% {
+      -webkit-mask-position: center 0;
+      mask-position: center 0
+  }
+
+  to {
+      -webkit-mask-position: center 1.2rem;
+      mask-position: center 1.2rem
+  }
+}
+
+@keyframes future-tv-lines {
+  0% {
+      -webkit-mask-position: center 0;
+      mask-position: center 0
+  }
+
+  to {
+      -webkit-mask-position: center 1.2rem;
+      mask-position: center 1.2rem
+  }
+}

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -45,6 +45,11 @@ body {
     /* opacity: 0.2; */
     margin: 1rem;
 }
+
+.card-punks-stats {
+  box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.49)
+}
+
 th, td {
     padding: 0.25rem;
 }
@@ -81,6 +86,9 @@ tr.btm th:last-child, tr.btm td:last-child {
     }
     .card {
         max-width: 700px;
+    }
+    .card-punks-stats {
+      visibility: hidden;
     }
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,9 @@
 <!-- CSS -->
 <link rel="stylesheet" href="../static/style.css" />
 
+<script src="static/ethers-5.4.umd.min.js" type="application/javascript"></script>
+<script src="static/app.js" type="application/javascript"></script>
+
 <!-- Nav Bar -->
 <nav class="navbar navbar-expand-xl navbar-dark">
     <a class="navbar-brand mb-0" href="/" style="padding: 0; margin: 0 0.5rem; vertical-align: middle; display: flex; align-items: center;">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -373,13 +373,15 @@
                                     </table>                                
                                 </div>
                             {% endif %}
-                            <img src="https://raw.githubusercontent.com/BlockNG-Foundation/LawPunks/main/assets/images/{{id}}.png" width="100%"  onmouseover="onPunkHover(event, {{ id }})" onmouseleave="onPunkLeaveHover({{ id }})"/>
+                            <img class="global-pixelated global-tv" src="https://raw.githubusercontent.com/BlockNG-Foundation/LawPunks/main/assets/images/{{id}}.png" width="100%"  onmouseover="onPunkHover(event, {{ id }})" onmouseleave="onPunkLeaveHover({{ id }})"/>
                             <small>
+                                {% if date %}
+                                <!-- Only show ID# on Yields Page, otherwise we have the popover -->
+                                <!-- Need a better option, to account for mobile... -->
                                 <p style="margin-bottom: 0;">
                                     #{{id}}
-                                    <!-- <br>
-                                    Lvl: {{ "{:,.0f}".format(punks[id|string]["Level"]) }} -->
                                 </p>
+                                {% endif %}
                             </small>
                         </a>
                     </td>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -84,7 +84,7 @@
             <div class="card-header">
                 <H3>Staked tokens balance in the portfolio:</H3>
                 <small>For information on Celery modes, see proposal  
-                    <a href="https://transparency.smartindex.cash/proposals/16">#16</a>
+                    <a href="https://transparency.smartindex.cash/proposals/16" target="_blank">#16</a>
                 </small>
             </div>
             <div class="card-body">
@@ -101,7 +101,7 @@
                             <td>{{ key }}
                                 {% if key == "Celery" %}
                                     {% if "Mode" in value %}
-                                        (<a href="https://transparency.smartindex.cash/proposals/16">{{ value["Mode"] }}</a>)
+                                        (<a href="https://transparency.smartindex.cash/proposals/16" target="_blank">{{ value["Mode"] }}</a>)
                                     {% endif %}
                                 {% endif %}
                             </td>
@@ -204,9 +204,9 @@
         <div class="card-header">
             <H3>Extra SIDX liquidity pools:</H3>
             <small>See proposals 
-                <a href="https://transparency.smartindex.cash/proposals/10">#10</a>, 
-                <a href="https://transparency.smartindex.cash/proposals/19">#19</a> and 
-                <a href="https://transparency.smartindex.cash/proposals/21">#21</a>
+                <a href="https://transparency.smartindex.cash/proposals/10" target="_blank">#10</a>, 
+                <a href="https://transparency.smartindex.cash/proposals/19" target="_blank">#19</a> and 
+                <a href="https://transparency.smartindex.cash/proposals/21" target="_blank">#21</a>
             </small>
         </div>
         <div class="card-body">
@@ -333,12 +333,56 @@
                 {% if loop.index > 1 %}
                     <tr class="blank_row"><td colspan="4"></td></tr>
                 {% endif %}
-            <tr class="top highlight-color1"><th colspan="6">Wallet: <a href="https://www.smartscan.cash/address/{{key}}">{{key}}</a></th></tr>
+            <tr class="top highlight-color1"><th colspan="5">Wallet: <a href="https://sonar.cash/address/{{key}}" target="_blank">{{key}}</a></th></tr>
             <tr class="highlight-color1">
-                <td style="width: 5000px;">Punks: </td>
                 {% for id in value["Punks"] %}
                     <!-- False, large width for even spacing -->
-                    <td style="width: 5000px; text-align: center;"><a href="https://blockng.money/#/detail/{{id}}"><img src="https://raw.githubusercontent.com/BlockNG-Foundation/LawPunks/main/assets/images/{{id}}.png" width="100%"/>#{{id}}</a></td>
+                    <td style="width: 5000px; text-align: center; position: relative;">
+                        <a href="https://blockng.money/#/detail/{{id}}" target="_blank">
+                            {% if title == "Portfolio tracker" %}
+                                <!-- Hidden Div for Punk Stats -->
+                                <div id="{{id}}" class="card card-punks-stats" style="position: absolute; left: -250px; top: -200px; display:none; width: 250px; padding: 1rem;"> <!-- background-color: #3f627c; -->
+                                    <table id="law_punks" style="width: 100%;">
+                                        <tr class="top btm highlight-color2"><th colspan="2">LawPunk #{{ id }}</th></tr>
+                                        <tr class="blank_row"><td colspan="2"></td></tr>
+                                        <tr class="top highlight-color1">
+                                            <th style="text-align: left;">Level:</th>
+                                            <th style="text-align: right;">{{ "{:,.0f}".format(punks[id|string]["Level"]) }}</th>
+                                        </tr>
+                                        <tr class="highlight-color1">
+                                            <td style="text-align: left;">Bloodline:</td>
+                                            <td style="text-align: right;">{{ "{:,.3f}".format(punks[id|string]["Bloodline"]) }}</td>
+                                        </tr>
+                                        <tr class="highlight-color1">
+                                            <td style="text-align: left;">Popularity:</td>
+                                            <td style="text-align: right;">{{ "{:,.3f}".format(punks[id|string]["Popularity"]) }}</td>
+                                        </tr>
+                                        <tr class="highlight-color1">
+                                            <td style="text-align: left;">Growth:</td>
+                                            <td style="text-align: right;">{{ "{:,.3f}".format(punks[id|string]["Growth"]) }}</td>
+                                        </tr>
+                                        <tr class="btm highlight-color2">
+                                            <th style="text-align: left;">Total Power:</th>
+                                            <th style="text-align: right;">{{ "{:,.3f}".format(punks[id|string]["Power"]) }}</th>
+                                        </tr>
+                                        <tr class="blank_row"><td colspan="2"></td></tr>
+                                        <tr class="top btm highlight-color2">
+                                            <th style="text-align: left;">Base Hashrate:</th>
+                                            <th style="text-align: right;">{{ "{:,.3f}".format(punks[id|string]["Hashrate"]) }}</th>
+                                        </tr>
+                                    </table>                                
+                                </div>
+                            {% endif %}
+                            <img src="https://raw.githubusercontent.com/BlockNG-Foundation/LawPunks/main/assets/images/{{id}}.png" width="100%"  onmouseover="onPunkHover(event, {{ id }})" onmouseleave="onPunkLeaveHover({{ id }})"/>
+                            <small>
+                                <p style="margin-bottom: 0;">
+                                    #{{id}}
+                                    <!-- <br>
+                                    Lvl: {{ "{:,.0f}".format(punks[id|string]["Level"]) }} -->
+                                </p>
+                            </small>
+                        </a>
+                    </td>
                     {% if loop.index < 5 and loop.index == loop|length %}
                         {% for n in range (5 - loop.index) %}
                             <td> </td>
@@ -347,27 +391,27 @@
                 {% endfor %}
             </tr>
             <tr class="btm highlight-color1">
-                <th colspan="5">LAW earned:</td>
+                <th colspan="4">LAW earned:</td>
                 <th style="text-align: right;">{{ "{:,.2f}".format(value["LAW rewards"]|float) }} LAW</td>
             </tr>
             {% endfor %}
             <tr class="blank_row"><td colspan="6"></td></tr>
             <tr class="top highlight-color1">
-                <td colspan="4">Total LAW Earned:</td>
+                <td colspan="3">Total LAW Earned:</td>
                 <td colspan="2" style="text-align: right;">{{ "{:,.2f}".format(punks["Total LAW pending"]|float) }} LAW</td>
             </tr>
             <tr class="btm highlight-color1">
-                <th colspan="4">Total USD Value:</th>
+                <th colspan="3">Total USD Value:</th>
                 <th colspan="2" style="text-align: right;">$ {{ "{:,.2f}".format(punks["LAW pending in USD"]|float) }}</th>
             </tr>
             {% if punks["Floor price"] %}
             <tr class="blank_row"><td colspan="6"></td></tr>
             <tr class="top highlight-color1">
-                <td colspan="4">Punks floor price:</td>
+                <td colspan="3">Punks floor price:</td>
                 <td colspan="2" style="text-align: right;">{{ "{:,.2f}".format(punks["Floor price"]|float) }} BCH</td>
             </tr>
             <tr class="btm highlight-color1">
-                <th colspan="4">Total floor value:</th>
+                <th colspan="3">Total floor value:</th>
                 <th colspan="2" style="text-align: right;">$ {{ "{:,.2f}".format(punks["Total floor value"]|float) }}</th>
             </tr>
             {% endif %}
@@ -394,7 +438,7 @@
                     {% else %}
                         <tr class="highlight-color1">
                     {% endif %}
-                    <td><a href="https://oasis.cash/token/0xe24Ed1C92feab3Bb87cE7c97Df030f83E28d9667/{{key}}">#{{key}}</a></td>
+                    <td><a href="https://oasis.cash/token/0xe24Ed1C92feab3Bb87cE7c97Df030f83E28d9667/{{key}}" target="_blank">#{{key}}</a></td>
                     <td>{{ value["Unlock Date"] }}</td>
                     {% if "Vote Power" in value %}
                         <td style="text-align: right;">{{ "{:,.2f}".format(value["Vote Power"]|float) }}</td>

--- a/app/templates/proposals.html
+++ b/app/templates/proposals.html
@@ -1,11 +1,6 @@
 {% extends "base.html" %}
 
 {% block app_content %}
-<script src="static/ethers-5.4.umd.min.js"
-        type="application/javascript"></script>
-<script src="static/app.js" type="application/javascript"></script>
-<link rel="stylesheet" href="../static/style.css" />
-
 
 <div class="card">
   <div class="card-header"><H2>SmartIndex Proposals:</H2></div>


### PR DESCRIPTION
Added LawPunk popovers on mouseover to display stats.
- Only available ln non-mobile (over 1200px wide).
- Displays base hashrate, currently waiting on ABI to check for LawPunks Items for total hash rate.
- Added an if block to only show popovers on index page, not snapshots.
- Had to add an if statement in the web3 functions in `app.js` so I could import it elsewhere in the app.
- Oh, and I also added sonar.cash instead on smartscan.cash in links. Just feel it looks better , but once again, not trying to make too many calls here. 

Add an `import math` in `engine.py` so I could get the square root of power to equal hashrate.

I think this PR is solid, but please check it out fully.

https://user-images.githubusercontent.com/98292681/192418551-50cc2d4b-eef1-4d8c-aea9-3b367b18f825.mp4
